### PR TITLE
Adopt case-utils 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.10-slim-bullseye
 WORKDIR /opt/workspace
 
 # Install dependencies
-RUN python -m pip install case-utils==0.10.0
+RUN python -m pip install case-utils==0.11.0
 
 # Delete source files now that package has been installed
 WORKDIR /opt/workspace

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Include the validation action in your GitHub action workflow and specify the fil
 ```yaml
 # Run the CASE validation job to confirm the output is valid
 - name: CASE Export Validation
-  uses: kchason/case-validation-action@v2.7
+  uses: kchason/case-validation-action@v2.6.1
   with:
     case-path: ./output/
     case-version: "case-1.2.0"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Include the validation action in your GitHub action workflow and specify the fil
 ```yaml
 # Run the CASE validation job to confirm the output is valid
 - name: CASE Export Validation
-  uses: kchason/case-validation-action@v2.6
+  uses: kchason/case-validation-action@v2.7
   with:
     case-path: ./output/
     case-version: "case-1.2.0"


### PR DESCRIPTION
This patch has no functional impact on the operations of this GitHub Action, as `case_validate` was not modified between `case-utils` 0.10.0 and 0.11.0.  For adopters of this Action who also import `case-utils` for Python reasons, the Action will be known to be running the same `case-utils` version as among their package dependencies.

The PR will include a second patch to bump the version of the Action, because this repository is following what is, or is analogous to, the [CDO Continuous Release branching practice](https://cyberdomainontology.org/ontology/development/#branching-cdo-continuous).