### PR TITLE
Limit Annotation Workflows

### DIFF
--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -4,8 +4,10 @@ on: [ pull_request ]
 
 jobs:
   annotate:
+    if: github.event.pull_request.head.user == 'kchason'
     runs-on: ubuntu-latest
-    steps:
+    steps:      
+
       # Get the code from the repository to be packaged
       - name: Get Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Due to the permission issue in https://github.com/kchason/case-validation-action/pull/18 and documentation in https://github.com/actions/first-interaction/issues/10, this only runs the annotation workflow when it's a pull request from the `kchason` repository.